### PR TITLE
fix: render border colors in Avatar with placeholder initials

### DIFF
--- a/src/lib/components/Avatar/Avatar.spec.tsx
+++ b/src/lib/components/Avatar/Avatar.spec.tsx
@@ -53,7 +53,17 @@ describe('Components / Avatar', () => {
         </Flowbite>,
       );
 
-      expect(initialsPlaceholder()).toHaveTextContent('RR');
+      expect(initialsPlaceholderText()).toHaveTextContent('RR');
+    });
+
+    it('should support border color with placeholder initials', () => {
+      render(
+        <Flowbite>
+          <Avatar placeholderInitials="RR" bordered color="success" />
+        </Flowbite>,
+      );
+
+      expect(initialsPlaceholder()).toHaveClass('ring-green-500 dark:ring-green-500');
     });
   });
   describe('Image', () => {
@@ -71,3 +81,4 @@ describe('Components / Avatar', () => {
 
 const img = () => screen.getByTestId('flowbite-avatar-img');
 const initialsPlaceholder = () => screen.getByTestId('flowbite-avatar-initials-placeholder');
+const initialsPlaceholderText = () => screen.getByTestId('flowbite-avatar-initials-placeholder-text');

--- a/src/lib/components/Avatar/Avatar.tsx
+++ b/src/lib/components/Avatar/Avatar.tsx
@@ -102,9 +102,11 @@ const AvatarComponent: FC<AvatarProps> = ({
               rounded && theme.rounded,
               stacked && theme.stacked,
               bordered && theme.bordered,
+              bordered && theme.color[color],
             )}
+            data-testid="flowbite-avatar-initials-placeholder"
           >
-            <span className={classNames(theme.initials.text)} data-testid="flowbite-avatar-initials-placeholder">
+            <span className={classNames(theme.initials.text)} data-testid="flowbite-avatar-initials-placeholder-text">
               {placeholderInitials}
             </span>
           </div>


### PR DESCRIPTION
## Description

This PR fixes an issue with the `Avatar` component where the `color` prop is ignored when using placeholder initials.

Partially Fixes #451

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Breaking changes

None

## How Has This Been Tested?

- [X] Added a new unit test to verify expected classnames are applied in the appropriate scenario

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
